### PR TITLE
Fix CRA start on Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This is an e-commerce website built with React, Redux, Node.js, MongoDB, and Mon
 </ul>
 
 ## Installation
+Ensure you have Node.js 16 or later installed. If you use Node 17 or newer, set
+`NODE_OPTIONS=--openssl-legacy-provider` when running the development servers to
+avoid OpenSSL issues.
 <ol>
 <li>Clone the repository: git clone https://github.com/Nitish-JS/Ecommerce.git</li>
 <li>Navigate to the project directory: cd Ecommerce</li>

--- a/admin/package.json
+++ b/admin/package.json
@@ -23,8 +23,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -29,8 +29,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Summary
- allow React dev servers to run on Node 17+
- document the need to use `NODE_OPTIONS` when using newer Node versions

## Testing
- `npm test --silent --prefix client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd78addf48326a50742081349ef7b