### PR TITLE
Update CRA scripts and add overrides

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "recharts": "^2.0.9",
     "redux-persist": "^6.0.0",
     "timeago.js": "^4.0.2",
@@ -45,5 +45,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "postcss-safe-parser": "^6.0.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.4",
     "react-router-dom": "^5.3.4",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "react-stripe-checkout": "^2.6.3",
     "react-toastify": "^8.0.3",
     "redux-persist": "^6.0.0",
@@ -64,5 +64,8 @@
   "bugs": {
     "url": "https://github.com/Nitish-JS/IWP/issues"
   },
-  "homepage": "/"
+  "homepage": "/",
+  "overrides": {
+    "postcss-safe-parser": "^6.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- update `react-scripts` to `^5.0.1`
- add npm overrides for `postcss-safe-parser`

## Testing
- `npm run build` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*
- `npm run build` in admin *(fails: react-scripts not found)*
- `npm install` in client and admin *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686be677d24083269d38453373a405ed