### PR TITLE
Add dark theme support

### DIFF
--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -2,8 +2,8 @@ import { createGlobalStyle } from "styled-components";
 
 export const GlobalStyles = createGlobalStyle`
   body {
-    background-color: ${({ theme }) => theme.bg};
+    background: ${({ theme }) => theme.bg};
     color: ${({ theme }) => theme.text};
-    transition: background-color 0.3s ease, color 0.3s ease;
+    transition: background 0.3s ease, color 0.3s ease;
   }
 `;

--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from "styled-components";
+
+export const GlobalStyles = createGlobalStyle`
+  body {
+    background-color: ${({ theme }) => theme.bg};
+    color: ${({ theme }) => theme.text};
+    transition: background-color 0.3s ease, color 0.3s ease;
+  }
+`;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -6,6 +6,7 @@ import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import { mobile } from "../responsive";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
+import { useDarkMode } from "../darkModeContext";
 
 const Container = styled.div`
   height: 60px;
@@ -71,9 +72,24 @@ const Menu = styled.div`
   ${mobile({ fontSize: "12px", marginLeft: "10px" })}
 `;
 
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: ${({ theme }) => theme.text};
+`;
+
+const ThemeToggle = styled.button`
+  margin-left: 25px;
+  background: none;
+  border: 1px solid ${({ theme }) => theme.text};
+  color: ${({ theme }) => theme.text};
+  cursor: pointer;
+  ${mobile({ fontSize: "12px", marginLeft: "10px" })}
+`;
+
 const Navbar = () => {
   const quantity = useSelector((state) => state.cart.quantity);
   const user = useSelector((state) => state.user.currentUser);
+  const { toggle } = useDarkMode();
   // console.log(quantity);
   return (
     <Container>
@@ -88,21 +104,15 @@ const Navbar = () => {
         <Right>
           {!user ? (
             <>
-              <Link
-                style={{ textDecoration: "none", color: "black" }}
-                to="/register"
-              >
+              <StyledLink to="/register">
                 <Menu>REGISTER</Menu>
-              </Link>
-              <Link
-                style={{ textDecoration: "none", color: "black" }}
-                to="/login"
-              >
+              </StyledLink>
+              <StyledLink to="/login">
                 <Menu>SIGN IN</Menu>
-              </Link>
+              </StyledLink>
             </>
           ) : (
-            <Link style={{ textDecoration: "none", color: "black" }} to="/">
+            <StyledLink to="/">
               <Menu
                 onClick={() => {
                   localStorage.clear();
@@ -111,16 +121,17 @@ const Navbar = () => {
               >
                 SIGN OUT
               </Menu>
-            </Link>
+            </StyledLink>
           )}
 
           <Menu>
-            <Link style={{ textDecoration: "none", color: "black" }} to="/cart">
+            <StyledLink to="/cart">
               <Badge badgeContent={quantity} color="primary">
                 <ShoppingCartIcon />
               </Badge>
-            </Link>
+            </StyledLink>
           </Menu>
+          <ThemeToggle onClick={toggle}>Toggle Theme</ThemeToggle>
         </Right>
       </Wrapper>
     </Container>

--- a/client/src/components/Product.jsx
+++ b/client/src/components/Product.jsx
@@ -63,7 +63,7 @@ const Icon = styled.div`
   }
 `;
 const Price = styled.p`
-  color: black;
+  color: ${({ theme }) => theme.text};
   text-align: center;
 `;
 const Product = ({ item }) => {

--- a/client/src/components/Product.jsx
+++ b/client/src/components/Product.jsx
@@ -28,7 +28,7 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background-color: #f5fbfd;
+  background-color: ${({ theme }) => theme.gridBg};
   position: relative;
   &:hover ${Info} {
     opacity: 1;

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -4,6 +4,11 @@ import { useState } from "react";
 import { sliderItems } from "../data";
 import { Link } from "react-router-dom";
 import { mobile } from "../responsive";
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: ${({ theme }) => theme.text};
+`;
 const Container = styled.div`
   width: 100%;
   height: 80vh;
@@ -102,12 +107,9 @@ const Slider = () => {
               <InfoContainer>
                 <Title>{item.title}</Title>
                 <Description>{item.desc}</Description>
-                <Link
-                  style={{ textDecoration: "none", color: "black" }}
-                  to="/products/men"
-                >
+                <StyledLink to="/products/men">
                   <Button>Shop Now</Button>
-                </Link>
+                </StyledLink>
               </InfoContainer>
             </Slide>
           );

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -36,6 +36,7 @@ const Arrow = styled.div`
   cursor: pointer;
   opacity: 0.75;
   z-index: 2;
+  color: black;
 `;
 
 const Wrapper = styled.div`
@@ -82,6 +83,8 @@ const Button = styled.button`
   font-size: 20px;
   background-color: transparent;
   cursor: pointer;
+  color: ${({ theme }) => theme.text};
+  border: 1px solid ${({ theme }) => theme.text};
 `;
 
 const Slider = () => {

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -67,6 +67,8 @@ const InfoContainer = styled.div`
 
 const Title = styled.h1`
   font-size: 70px;
+  font-family: 'Courier New', cursive;
+  color: #ff6347;
 `;
 const Description = styled.p`
   margin: 50px 0;

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -50,7 +50,7 @@ const Slide = styled.div`
   height: 100%;
   display: flex;
   align-items: center;
-  background-color: #${(props) => props.bg};
+  background: ${({ theme, bg }) => theme.sliderBg || `#${bg}`};
 `;
 const ImageContainer = styled.div`
   height: 80%;
@@ -75,7 +75,7 @@ const Description = styled.p`
   font-size: 20px;
   font-weight: 500;
   letter-spacing: 3px;
-  color: #333;
+  color: ${({ theme }) => theme.text};
 `;
 const Button = styled.button`
   padding: 10px;

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -75,6 +75,7 @@ const Description = styled.p`
   font-size: 20px;
   font-weight: 500;
   letter-spacing: 3px;
+  color: #333;
 `;
 const Button = styled.button`
   padding: 10px;

--- a/client/src/darkModeContext.js
+++ b/client/src/darkModeContext.js
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+const DarkModeContext = createContext();
+
+export const DarkModeProvider = ({ children }) => {
+  const [mode, setMode] = useState(localStorage.getItem("theme") || "light");
+
+  useEffect(() => {
+    localStorage.setItem("theme", mode);
+  }, [mode]);
+
+  const toggle = () => {
+    setMode((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <DarkModeContext.Provider value={{ mode, toggle }}>
+      {children}
+    </DarkModeContext.Provider>
+  );
+};
+
+export const useDarkMode = () => useContext(DarkModeContext);

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,12 +4,28 @@ import App from "./App";
 import { Provider } from "react-redux";
 import { store, persistor } from "./redux/store";
 import { PersistGate } from "redux-persist/integration/react";
+import { ThemeProvider } from "styled-components";
+import { lightTheme, darkTheme } from "./theme";
+import { GlobalStyles } from "./GlobalStyles";
+import { DarkModeProvider, useDarkMode } from "./darkModeContext";
+
+const ThemedApp = () => {
+  const { mode } = useDarkMode();
+  return (
+    <ThemeProvider theme={mode === "light" ? lightTheme : darkTheme}>
+      <GlobalStyles />
+      <App />
+    </ThemeProvider>
+  );
+};
 
 
 ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
-      <App />
+      <DarkModeProvider>
+        <ThemedApp />
+      </DarkModeProvider>
     </PersistGate>
   </Provider>,
   document.getElementById("root")

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -16,8 +16,16 @@ import {
   itemAddHandler,
 } from "../redux/cartRedux";
 
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: ${({ theme }) => theme.text};
+`;
+
 const KEY = process.env.REACT_APP_STRIPE;
-const Container = styled.div``;
+const Container = styled.div`
+  background: ${({ theme }) => theme.bg};
+  color: ${({ theme }) => theme.text};
+`;
 const Wrapper = styled.div`
   padding: 20px;
   ${mobile({ padding: "10px" })}
@@ -200,9 +208,9 @@ const Cart = () => {
       <Wrapper>
         <Title>Your Cart</Title>
         <Top>
-          <Link style={{ textDecoration: "none", color: "black" }} to="/">
+          <StyledLink to="/">
             <TopButton>Continue Shopping</TopButton>
-          </Link>
+          </StyledLink>
           <TopButton type="filled" onClick={handleClick}>
             EMPTY CART
           </TopButton>
@@ -287,12 +295,9 @@ const Cart = () => {
               <Button>CHECKOUT NOW</Button>
             </StripeCheckout>
             <Button style={{ marginTop: "30px" }}>
-              <Link
-                style={{ textDecoration: "none", color: "white" }}
-                to={`/orderdetails/${currentUser._id}`}
-              >
+              <StyledLink to={`/orderdetails/${currentUser._id}`}>
                 ORDER DETAILS
-              </Link>
+              </StyledLink>
             </Button>
 
             {/* <Button>Checkout Now</Button> */}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -9,15 +9,12 @@ import { notifySuccess, notifyFailure, notifyInfo } from "../components/alert";
 const Container = styled.div`
   width: 100vw;
   height: 100vh;
-  background: linear-gradient(
-      rgba(255, 255, 255, 0.5),
-      rgba(255, 255, 255, 0.5)
-    ),
-      center;
+  background: ${({ theme }) => theme.bg};
   background-size: cover;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: ${({ theme }) => theme.text};
 `;
 
 const Wrapper = styled.div`

--- a/client/src/pages/ProductList.jsx
+++ b/client/src/pages/ProductList.jsx
@@ -7,7 +7,10 @@ import Navbar from "../components/Navbar";
 import Products from "../components/Products";
 import { mobile } from "../responsive";
 
-const Container = styled.div``;
+const Container = styled.div`
+  background: ${({ theme }) => theme.bg};
+  color: ${({ theme }) => theme.text};
+`;
 const Title = styled.h1`
   margin: 20px;
 `;

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -10,7 +10,10 @@ import { publicRequest } from "../requestMethods";
 import { useState, useEffect } from "react";
 import { addProduct } from "../redux/cartRedux";
 import { useDispatch } from "react-redux";
-const Container = styled.div``;
+const Container = styled.div`
+  background: ${({ theme }) => theme.bg};
+  color: ${({ theme }) => theme.text};
+`;
 const Wrapper = styled.div`
   padding: 50px;
   display: flex;

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -8,14 +8,12 @@ import { notifySuccess, notifyFailure, notifyInfo } from "../components/alert";
 const Container = styled.div`
   width: 100vw;
   height: 100vh;
-  background: linear-gradient(
-    rgba(255, 255, 255, 0.5),
-    rgba(255, 255, 255, 0.5)
-  );
+  background: ${({ theme }) => theme.bg};
   background-size: cover;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: ${({ theme }) => theme.text};
 `;
 
 const Wrapper = styled.div`

--- a/client/src/pages/Sucess.jsx
+++ b/client/src/pages/Sucess.jsx
@@ -17,6 +17,21 @@ const Container = styled.div`
   justify-content: space-around;
   flex-direction: column;
   height: 100vh;
+  background: ${({ theme }) => theme.bg};
+  color: ${({ theme }) => theme.text};
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: ${({ theme }) => theme.text};
+`;
+
+const OrderButton = styled.button`
+  padding: 10px;
+  margin-top: 80px;
+  background-color: black;
+  color: ${({ theme }) => theme.text};
+  cursor: pointer;
 `;
 const Title = styled.div`
   display: flex;
@@ -155,19 +170,9 @@ const Success = () => {
             </div>
           </Div>
         )}
-        <Link to={`/orderdetails/${orderedItems._id}`}>
-          <button
-            style={{
-              padding: 10,
-              marginTop: 80,
-              backgroundColor: "black",
-              color: "white",
-              cursor: "pointer",
-            }}
-          >
-            Order Details
-          </button>
-        </Link>
+        <StyledLink to={`/orderdetails/${orderedItems._id}`}>
+          <OrderButton>Order Details</OrderButton>
+        </StyledLink>
       </Left>
       {/* <Right>
         <Top></Top>

--- a/client/src/pages/orderDetails.jsx
+++ b/client/src/pages/orderDetails.jsx
@@ -14,6 +14,11 @@ import { notifyInfo } from "../components/alert";
 import { addOrder, setStatus } from "../redux/orderRedux";
 
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: ${({ theme }) => theme.text};
+`;
 const Container = styled.div`
   display: flex;
   align-items: center;
@@ -21,6 +26,8 @@ const Container = styled.div`
   height: 100vh;
   flex-direction: column;
   overflow: auto;
+  background: ${({ theme }) => theme.bg};
+  color: ${({ theme }) => theme.text};
 `;
 const Product = styled.div`
   display: flex;
@@ -269,9 +276,7 @@ const OrderDetails = () => {
           <Title>No Orders</Title>
           <RemoveShoppingCartIcon style={{ fontSize: "100px", color: "red" }} />
           <HomeButton>
-            <Link style={{ textDecoration: "none", color: "white" }} to="/">
-              Back To Home Page
-            </Link>
+            <StyledLink to="/">Back To Home Page</StyledLink>
           </HomeButton>
         </NoOrderDiv>
       )}

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,0 +1,9 @@
+export const lightTheme = {
+  bg: "#ffffff",
+  text: "#000000",
+};
+
+export const darkTheme = {
+  bg: "#121212",
+  text: "#ffffff",
+};

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,9 +1,11 @@
 export const lightTheme = {
   bg: "#ffffff",
   text: "#000000",
+  gridBg: "#f5fbfd",
 };
 
 export const darkTheme = {
   bg: "linear-gradient(180deg, #0f2027, #203a43, #2c5364)",
   text: "#ffffff",
+  gridBg: "rgba(255, 255, 255, 0.1)",
 };

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -2,10 +2,12 @@ export const lightTheme = {
   bg: "#ffffff",
   text: "#000000",
   gridBg: "#f5fbfd",
+  sliderBg: null,
 };
 
 export const darkTheme = {
   bg: "linear-gradient(180deg, #0f2027, #203a43, #2c5364)",
   text: "#ffffff",
   gridBg: "rgba(255, 255, 255, 0.1)",
+  sliderBg: "rgba(0, 0, 0, 0.5)",
 };

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -4,6 +4,6 @@ export const lightTheme = {
 };
 
 export const darkTheme = {
-  bg: "#121212",
+  bg: "linear-gradient(180deg, #0f2027, #203a43, #2c5364)",
   text: "#ffffff",
 };


### PR DESCRIPTION
## Summary
- add dark mode context and theme objects
- wrap app with ThemeProvider and provide toggle button
- apply global styles and update navbar links

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_686beeaca6a0832695e710bdef859fe8