### PR TITLE
Fix port logging

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,7 @@ app.use("/api/cart", cartRoute);
 app.use("/api/order", orderRoute);
 app.use("/api/checkout", razorRoute);
 
-app.listen(process.env.PORT || 8000, () => {
-  console.log("server listening at port 8000");
+const port = process.env.PORT || 8000;
+app.listen(port, () => {
+  console.log(`server listening at port ${port}`);
 });


### PR DESCRIPTION
## Summary
- output actual server port in log message

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider CI=true npm test --silent` in `client`
- `NODE_OPTIONS=--openssl-legacy-provider CI=true npm test --silent` in `admin`

------
https://chatgpt.com/codex/tasks/task_e_686c98f8c0ac832699f93527dd8998fb