### PR TITLE
Fix login credential typos

### DIFF
--- a/admin/src/pages/login/Login.jsx
+++ b/admin/src/pages/login/Login.jsx
@@ -12,7 +12,7 @@ const Login = () => {
     if (email !== "" && password !== "") {
       login(dispatch, { email, password });
     } else {
-      alert("Enter Valid Credentails");
+      alert("Enter valid credentials");
     }
   };
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -27,7 +27,7 @@ router.post("/login", async (req, res) => {
   try {
     const user = await User.findOne({ email: req.body.email });
     if (user === null) {
-      return res.status(401).json("Invalid credentails!");
+      return res.status(401).json("Invalid credentials!");
     }
 
     const hashedPassword = CryptoJS.AES.decrypt(user.password, process.env.KEY);


### PR DESCRIPTION
## Summary
- correct typo in server login response
- fix admin login alert wording

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `admin`


------
https://chatgpt.com/codex/tasks/task_e_686ca5efcf1483269f1d9bfa82b86324