### PR TITLE
Add dark mode toggle

### DIFF
--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -2,9 +2,9 @@ import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
   body {
-    background-color: ${(props) => props.theme.body};
+    background: ${(props) => props.theme.body};
     color: ${(props) => props.theme.text};
-    transition: background-color 0.3s linear, color 0.3s linear;
+    transition: background 0.3s linear, color 0.3s linear;
   }
 `;
 

--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -1,0 +1,11 @@
+import { createGlobalStyle } from "styled-components";
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    background-color: ${(props) => props.theme.body};
+    color: ${(props) => props.theme.text};
+    transition: background-color 0.3s linear, color 0.3s linear;
+  }
+`;
+
+export default GlobalStyle;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -6,6 +6,10 @@ import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import { mobile } from "../responsive";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
+import { useContext } from "react";
+import { ThemeContext } from "../themeContext";
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import LightModeIcon from "@mui/icons-material/LightMode";
 
 const Container = styled.div`
   height: 60px;
@@ -71,10 +75,18 @@ const Menu = styled.div`
   ${mobile({ fontSize: "12px", marginLeft: "10px" })}
 `;
 
+const ThemeToggle = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  margin-left: 20px;
+  color: ${(props) => props.theme.text};
+`;
+
 const Navbar = () => {
   const quantity = useSelector((state) => state.cart.quantity);
   const user = useSelector((state) => state.user.currentUser);
-  // console.log(quantity);
+  const { mode, toggleTheme } = useContext(ThemeContext);
   return (
     <Container>
       <Wrapper>
@@ -88,25 +100,19 @@ const Navbar = () => {
         <Right>
           {!user ? (
             <>
-              <Link
-                style={{ textDecoration: "none", color: "black" }}
-                to="/register"
-              >
+              <Link style={{ textDecoration: "none", color: "inherit" }} to="/register">
                 <Menu>REGISTER</Menu>
               </Link>
-              <Link
-                style={{ textDecoration: "none", color: "black" }}
-                to="/login"
-              >
+              <Link style={{ textDecoration: "none", color: "inherit" }} to="/login">
                 <Menu>SIGN IN</Menu>
               </Link>
             </>
           ) : (
-            <Link style={{ textDecoration: "none", color: "black" }} to="/">
+            <Link style={{ textDecoration: "none", color: "inherit" }} to="/">
               <Menu
                 onClick={() => {
                   localStorage.clear();
-                  window.location.replace('/')
+                  window.location.replace("/");
                 }}
               >
                 SIGN OUT
@@ -114,8 +120,12 @@ const Navbar = () => {
             </Link>
           )}
 
+          <ThemeToggle onClick={toggleTheme}>
+            {mode === "light" ? <DarkModeIcon /> : <LightModeIcon />}
+          </ThemeToggle>
+
           <Menu>
-            <Link style={{ textDecoration: "none", color: "black" }} to="/cart">
+            <Link style={{ textDecoration: "none", color: "inherit" }} to="/cart">
               <Badge badgeContent={quantity} color="primary">
                 <ShoppingCartIcon />
               </Badge>

--- a/client/src/components/Product.jsx
+++ b/client/src/components/Product.jsx
@@ -28,7 +28,7 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background-color: #f5fbfd;
+  background-color: ${(props) => props.theme.elementBg};
   position: relative;
   &:hover ${Info} {
     opacity: 1;
@@ -63,7 +63,7 @@ const Icon = styled.div`
   }
 `;
 const Price = styled.p`
-  color: black;
+  color: ${(props) => props.theme.text};
   text-align: center;
 `;
 const Product = ({ item }) => {

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -45,7 +45,10 @@ const Slide = styled.div`
   height: 100%;
   display: flex;
   align-items: center;
-  background-color: #${(props) => props.bg};
+  background: ${(props) =>
+    props.theme.mode === "dark"
+      ? `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), #${props.bg}`
+      : `#${props.bg}`};
 `;
 const ImageContainer = styled.div`
   height: 80%;
@@ -62,17 +65,20 @@ const InfoContainer = styled.div`
 
 const Title = styled.h1`
   font-size: 70px;
+  color: ${(props) => props.theme.text};
 `;
 const Description = styled.p`
   margin: 50px 0;
   font-size: 20px;
   font-weight: 500;
   letter-spacing: 3px;
+  color: ${(props) => props.theme.text};
 `;
 const Button = styled.button`
   padding: 10px;
   font-size: 20px;
   background-color: transparent;
+  color: ${(props) => props.theme.text};
   cursor: pointer;
 `;
 
@@ -103,7 +109,7 @@ const Slider = () => {
                 <Title>{item.title}</Title>
                 <Description>{item.desc}</Description>
                 <Link
-                  style={{ textDecoration: "none", color: "black" }}
+                  style={{ textDecoration: "none", color: "inherit" }}
                   to="/products/men"
                 >
                   <Button>Shop Now</Button>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,12 +4,28 @@ import App from "./App";
 import { Provider } from "react-redux";
 import { store, persistor } from "./redux/store";
 import { PersistGate } from "redux-persist/integration/react";
+import { ThemeProvider as StyledThemeProvider } from "styled-components";
+import { ThemeProvider, ThemeContext } from "./themeContext";
+import { lightTheme, darkTheme } from "./theme";
+import GlobalStyle from "./GlobalStyles";
 
+
+const ThemedApp = () => {
+  const { mode } = React.useContext(ThemeContext);
+  return (
+    <StyledThemeProvider theme={mode === "light" ? lightTheme : darkTheme}>
+      <GlobalStyle />
+      <App />
+    </StyledThemeProvider>
+  );
+};
 
 ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
-      <App />
+      <ThemeProvider>
+        <ThemedApp />
+      </ThemeProvider>
     </PersistGate>
   </Provider>,
   document.getElementById("root")

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -9,11 +9,7 @@ import { notifySuccess, notifyFailure, notifyInfo } from "../components/alert";
 const Container = styled.div`
   width: 100vw;
   height: 100vh;
-  background: linear-gradient(
-      rgba(255, 255, 255, 0.5),
-      rgba(255, 255, 255, 0.5)
-    ),
-      center;
+  background: ${(props) => props.theme.loginBg};
   background-size: cover;
   display: flex;
   align-items: center;
@@ -23,7 +19,7 @@ const Container = styled.div`
 const Wrapper = styled.div`
   width: 25%;
   padding: 20px;
-  background-color: white;
+  background-color: ${(props) => props.theme.cardBg};
   ${mobile({ width: "75%" })}
 `;
 

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -8,10 +8,7 @@ import { notifySuccess, notifyFailure, notifyInfo } from "../components/alert";
 const Container = styled.div`
   width: 100vw;
   height: 100vh;
-  background: linear-gradient(
-    rgba(255, 255, 255, 0.5),
-    rgba(255, 255, 255, 0.5)
-  );
+  background: ${(props) => props.theme.loginBg};
   background-size: cover;
   display: flex;
   align-items: center;
@@ -21,7 +18,7 @@ const Container = styled.div`
 const Wrapper = styled.div`
   width: 40%;
   padding: 20px;
-  background-color: white;
+  background-color: ${(props) => props.theme.cardBg};
   ${mobile({ width: "75%" })}
 `;
 

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,4 +1,5 @@
 export const lightTheme = {
+  mode: "light",
   body: "#ffffff",
   text: "#000000",
   elementBg: "#f5fbfd",
@@ -8,7 +9,8 @@ export const lightTheme = {
 };
 
 export const darkTheme = {
-  body: "#1e1e1e",
+  mode: "dark",
+  body: "linear-gradient(#2a2a2a, #1e1e1e)",
   text: "#f5f5f5",
   elementBg: "#2a2a2a",
   cardBg: "#333333",

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,0 +1,17 @@
+export const lightTheme = {
+  body: "#ffffff",
+  text: "#000000",
+  elementBg: "#f5fbfd",
+  cardBg: "#ffffff",
+  loginBg:
+    "linear-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)), center",
+};
+
+export const darkTheme = {
+  body: "#1e1e1e",
+  text: "#f5f5f5",
+  elementBg: "#2a2a2a",
+  cardBg: "#333333",
+  loginBg:
+    "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), center",
+};

--- a/client/src/themeContext.js
+++ b/client/src/themeContext.js
@@ -1,0 +1,26 @@
+import React, { createContext, useState, useEffect } from "react";
+
+export const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [mode, setMode] = useState("light");
+
+  useEffect(() => {
+    const saved = localStorage.getItem("themeMode");
+    if (saved) setMode(saved);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("themeMode", mode);
+  }, [mode]);
+
+  const toggleTheme = () => {
+    setMode((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- introduce theme context and styled-components ThemeProvider
- add dark and light theme styles
- apply theming to login and register pages
- use theme colors in product component
- update navbar with theme toggle icon

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `admin`


------
https://chatgpt.com/codex/tasks/task_e_686ca704fa0483269fde0860187ed9e1